### PR TITLE
[feat]: 회원 정보 조회 api 구현 (#12)

### DIFF
--- a/src/main/kotlin/com/mumulbo/auth/exception/errorCode/AuthErrorCode.kt
+++ b/src/main/kotlin/com/mumulbo/auth/exception/errorCode/AuthErrorCode.kt
@@ -8,5 +8,6 @@ enum class AuthErrorCode(
     override val code: String,
     override val message: String
 ) : ErrorCode {
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH-001", "인증되지 않은 요청입니다."),
     INVALID_TOKEN(HttpStatus.CONFLICT, "AUTH-002", "유효하지 않은 토큰입니다.")
 }

--- a/src/main/kotlin/com/mumulbo/auth/service/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/mumulbo/auth/service/JwtTokenProvider.kt
@@ -48,6 +48,7 @@ class JwtTokenProvider(
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token)
             return true
         } catch (e: JwtException) {
+            println("token: $token")
             return false
         }
     }
@@ -58,5 +59,14 @@ class JwtTokenProvider(
             .build()
             .parseClaimsJws(token)
             .body.subject
+    }
+
+    fun getIdFromToken(token: String): Long {
+        val claims = Jwts.parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .body
+        return claims["id"].toString().toLong()
     }
 }

--- a/src/main/kotlin/com/mumulbo/common/exception/UnauthorizedException.kt
+++ b/src/main/kotlin/com/mumulbo/common/exception/UnauthorizedException.kt
@@ -1,0 +1,5 @@
+package com.mumulbo.common.exception
+
+import com.mumulbo.auth.exception.errorCode.AuthErrorCode
+
+class UnauthorizedException : GlobalException(AuthErrorCode.UNAUTHORIZED)

--- a/src/main/kotlin/com/mumulbo/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/mumulbo/member/controller/MemberController.kt
@@ -1,8 +1,15 @@
 package com.mumulbo.member.controller
 
+import com.mumulbo.auth.exception.InvalidTokenException
+import com.mumulbo.auth.service.JwtTokenProvider
+import com.mumulbo.common.exception.UnauthorizedException
+import com.mumulbo.member.dto.response.MemberGetResponse
 import com.mumulbo.member.service.MemberService
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -11,8 +18,26 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/members")
 class MemberController(
-    private val memberService: MemberService
+    private val memberService: MemberService,
+    private val jwtTokenProvider: JwtTokenProvider
 ) {
+    @GetMapping("/me")
+    fun getMember(request: HttpServletRequest): ResponseEntity<MemberGetResponse> {
+        val header = request.getHeader("Authorization")
+        if (header == null || !header.startsWith("Bearer ")) {
+            throw UnauthorizedException()
+        }
+
+        val accessToken = header.substring(7)
+        if (!jwtTokenProvider.isValid(accessToken)) {
+            throw InvalidTokenException()
+        }
+
+        val id = jwtTokenProvider.getIdFromToken(accessToken)
+        val response = memberService.getMember(id)
+        return ResponseEntity.status(HttpStatus.OK).body(response)
+    }
+
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun withdraw(@PathVariable id: Long) =

--- a/src/main/kotlin/com/mumulbo/member/dto/response/MemberGetResponse.kt
+++ b/src/main/kotlin/com/mumulbo/member/dto/response/MemberGetResponse.kt
@@ -1,0 +1,15 @@
+package com.mumulbo.member.dto.response
+
+import com.mumulbo.member.entity.Member
+
+class MemberGetResponse(
+    val name: String,
+    val email: String,
+    val username: String
+) {
+    companion object {
+        fun of(member: Member): MemberGetResponse {
+            return MemberGetResponse(member.name, member.email, member.username)
+        }
+    }
+}

--- a/src/main/kotlin/com/mumulbo/member/entity/Member.kt
+++ b/src/main/kotlin/com/mumulbo/member/entity/Member.kt
@@ -9,14 +9,9 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import jakarta.persistence.UniqueConstraint
 
 @Entity
-@Table(
-    uniqueConstraints = [
-        UniqueConstraint(name = "member_unique_email", columnNames = ["email"])
-    ]
-)
+@Table
 class Member(
     @field:Column(nullable = false, length = 100)
     val name: String,

--- a/src/main/kotlin/com/mumulbo/member/service/MemberService.kt
+++ b/src/main/kotlin/com/mumulbo/member/service/MemberService.kt
@@ -1,5 +1,6 @@
 package com.mumulbo.member.service
 
+import com.mumulbo.member.dto.response.MemberGetResponse
 import com.mumulbo.member.exception.MemberNotFoundException
 import com.mumulbo.member.repository.MemberRepository
 import org.springframework.stereotype.Service
@@ -8,6 +9,11 @@ import org.springframework.stereotype.Service
 class MemberService(
     private val memberRepository: MemberRepository
 ) {
+    fun getMember(id: Long): MemberGetResponse {
+        val member = memberRepository.findById(id).orElseThrow { MemberNotFoundException() }
+        return MemberGetResponse.of(member)
+    }
+
     fun withdraw(id: Long) {
         val member = memberRepository.findById(id).orElseThrow { MemberNotFoundException() }
         memberRepository.delete(member)

--- a/src/test/kotlin/com/mumulbo/member/controller/MemberControllerTest.kt
+++ b/src/test/kotlin/com/mumulbo/member/controller/MemberControllerTest.kt
@@ -1,0 +1,101 @@
+package com.mumulbo.member.controller
+
+import com.mumulbo.auth.service.JwtTokenProvider
+import com.mumulbo.config.TestContainers
+import com.mumulbo.member.entity.Member
+import com.mumulbo.member.repository.MemberRepository
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class MemberControllerTest : TestContainers() {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var memberRepository: MemberRepository
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    private lateinit var member: Member
+
+    @BeforeEach
+    fun init() {
+        // given
+        val name = "송준희"
+        val email = "joonhee.song@ahnlab.com"
+        val username = "joonhee.song"
+        val password = "password"
+        member = memberRepository.save(Member(name, email, username, password))
+    }
+
+    @AfterEach
+    fun cleansing() {
+        memberRepository.deleteAllInBatch()
+    }
+
+    @DisplayName("성공-회원 정보 조회")
+    @Test
+    fun `success-get member`() {
+        // given
+        val accessToken = jwtTokenProvider.generateAccessToken(member.id!!, member.username, member.role)
+
+        // when // then
+        mockMvc.perform(
+            MockMvcRequestBuilders
+                .get("/api/v1/members/me")
+                .header("Authorization", "Bearer $accessToken")
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(jsonPath("$.name", `is`(member.name)))
+            .andExpect(jsonPath("$.email", `is`(member.email)))
+            .andExpect(jsonPath("$.username", `is`(member.username)))
+    }
+
+    @DisplayName("실패-토큰이 header에 없는 경우")
+    @Test
+    fun `fail-token is not found in header`() {
+        // when // then
+        mockMvc.perform(
+            MockMvcRequestBuilders
+                .get("/api/v1/members/me")
+        )
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized)
+            .andExpect(jsonPath("$.status", `is`(HttpStatus.UNAUTHORIZED.value())))
+            .andExpect(jsonPath("$.error", `is`("AUTH-001")))
+            .andExpect(jsonPath("$.message", `is`("인증되지 않은 요청입니다.")))
+    }
+
+    @DisplayName("실패-존재하지 않는 회원을 조회할 경우")
+    @Test
+    fun `fail-member not found`() {
+        // given
+        val accessToken = jwtTokenProvider.generateAccessToken(999_999L, member.username, member.role)
+
+        // when // then
+        mockMvc.perform(
+            MockMvcRequestBuilders
+                .get("/api/v1/members/me")
+                .header("Authorization", "Bearer $accessToken")
+        )
+            .andExpect(MockMvcResultMatchers.status().isNotFound)
+            .andExpect(jsonPath("$.status", `is`(HttpStatus.NOT_FOUND.value())))
+            .andExpect(jsonPath("$.error", `is`("MEMBER-001")))
+            .andExpect(jsonPath("$.message", `is`("존재하지 않는 회원입니다.")))
+    }
+}

--- a/src/test/kotlin/com/mumulbo/member/service/MemberServiceTest.kt
+++ b/src/test/kotlin/com/mumulbo/member/service/MemberServiceTest.kt
@@ -1,0 +1,63 @@
+package com.mumulbo.member.service
+
+import com.mumulbo.config.TestContainers
+import com.mumulbo.member.entity.Member
+import com.mumulbo.member.exception.MemberNotFoundException
+import com.mumulbo.member.repository.MemberRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@SpringBootTest
+@Testcontainers
+class MemberServiceTest : TestContainers() {
+    @Autowired
+    private lateinit var memberService: MemberService
+
+    @Autowired
+    private lateinit var memberRepository: MemberRepository
+
+    private lateinit var member: Member
+
+    @BeforeEach
+    fun init() {
+        // given
+        val name = "송준희"
+        val email = "joonhee.song@ahnlab.com"
+        val username = "joonhee.song"
+        val password = "password"
+        member = memberRepository.save(Member(name, email, username, password))
+    }
+
+    @AfterEach
+    fun cleansing() {
+        memberRepository.deleteAllInBatch()
+    }
+
+    @DisplayName("성공-회원 정보 조회")
+    @Test
+    fun `success-get member`() {
+        // when
+        val response = memberService.getMember(member.id!!)
+
+        // then
+        assertThat(response)
+            .extracting("name", "email", "username")
+            .contains(member.name, member.email, member.username)
+    }
+
+    @DisplayName("실패-존재하지 않는 회원")
+    @Test
+    fun test() {
+        // when // then
+        assertThatThrownBy { memberService.getMember(999_999L) }
+            .isInstanceOf(MemberNotFoundException::class.java)
+
+    }
+}


### PR DESCRIPTION
## PR Checklist
- [x] 테스트 코드 추가 여부
- [ ] 문서 작성/업데이트 여부


## PR Type
- [ ] 버그 수정 (Bugfix)
- [x] 기능 (Feature)
- [ ] 코드 포맷팅 (Code style update)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 배포 관련 수정 (Release)
- [ ] CI/CD related changes
- [ ] 문서 수정
- [ ] 구조 변경 (application / infrastructure changes)


## 이슈 번호 
close #12 

## 설명
Authorization Header에 담긴 Bearer Token을 받아 회원 정보를 조회합니다.

## 기타 전달 사항 (To reviewers)
주어진 시간 내에 기능을 구현하기 위해 spring security를 통해 jwt token을 처리하지 않고
controller에서 request의 header에서 직접 token을 꺼내 처리하도록 구현했습니다.